### PR TITLE
Persist aggregations

### DIFF
--- a/integration/integration_test_utils.py
+++ b/integration/integration_test_utils.py
@@ -1,0 +1,59 @@
+import aiohttp
+import json
+import random
+import asyncio
+import string
+import pytest
+
+from storey import NeedsV3ioAccess
+from storey.flow import _v3io_parse_get_items_response, V3ioError
+
+
+def _generate_table_name(prefix='bigdata/aggr_test'):
+    random_table = ''.join([random.choice(string.ascii_letters) for i in range(10)])
+    return f'{prefix}/{random_table}'
+
+
+@pytest.fixture()
+def setup_teardown_test():
+    # Setup
+    table_name = _generate_table_name()
+
+    # Test runs
+    yield table_name
+
+    # Teardown
+    asyncio.run(recursive_delete(table_name, NeedsV3ioAccess()))
+
+
+# Deletes the entire table
+async def recursive_delete(path, v3io_access):
+    connector = aiohttp.TCPConnector()
+    client_session = aiohttp.ClientSession(connector=connector)
+
+    has_more = True
+    next_marker = ''
+    while has_more:
+        get_items_body = {'AttributesToGet': '__name', 'Marker': next_marker}
+        response = await client_session.put(f'{v3io_access._webapi_url}/{path}/',
+                                                 headers=v3io_access._get_items_headers, data=json.dumps(get_items_body), ssl=False)
+        body = await response.text()
+        if response.status == 200:
+            res = _v3io_parse_get_items_response(body)
+            for item in res['Items']:
+                await _delete_item(f'{v3io_access._webapi_url}/{path}/{item["__name"]}', v3io_access, client_session)
+
+            has_more = 'NextMarker' in res
+            if has_more:
+                next_marker = res['NextMarker']
+        elif response.status != 404:
+            raise V3ioError(f'Failed to delete table {path}. Response status code was {response.status}: {body}')
+
+    await _delete_item(f'{v3io_access._webapi_url}/{path}/', v3io_access, client_session)
+
+
+async def _delete_item(path, v3io_access, client_session):
+    response = await client_session.delete(path, headers=v3io_access._get_put_file_headers, ssl=False)
+    if response.status > 300 and response.status != 404 and response.status != 409:
+        body = await response.text()
+        raise V3ioError(f'Failed to delete item at {path}. Response status code was {response.status}: {body}')

--- a/integration/test_aggregation_integration.py
+++ b/integration/test_aggregation_integration.py
@@ -1,0 +1,117 @@
+import asyncio
+import random
+import string
+from datetime import datetime, timedelta
+
+import pytest
+
+from storey import build_flow, Source, Reduce, V3ioTable
+from storey.aggregations import AggregateByKey, FieldAggregator, QueryAggregationByKey
+from storey.dtypes import SlidingWindows
+
+test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
+
+
+def _generate_table_name(prefix='aggr_test'):
+    random_table = ''.join([random.choice(string.ascii_letters) for i in range(10)])
+    return f'{prefix}/{random_table}'
+
+
+def append_return(lst, x):
+    lst.append(x)
+    return lst
+
+
+@pytest.fixture()
+def setup_teardown_test():
+    # Setup
+    table_name = _generate_table_name()
+    v3io_table = V3ioTable(table_name)
+
+    # Test runs
+    yield v3io_table
+
+    # Teardown
+    asyncio.run(v3io_table.delete())
+
+
+def test_query_aggregate_by_key(setup_teardown_test):
+    controller = build_flow([
+        Source(),
+        AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
+                                        SlidingWindows(['1h', '2h', '24h'], '10m'))],
+                       setup_teardown_test),
+        Reduce([], lambda acc, x: append_return(acc, x)),
+    ]).run()
+
+    items_in_ingest_batch = 10
+    for i in range(items_in_ingest_batch):
+        data = {'col1': i}
+        controller.emit(data, 'tal', test_base_time + timedelta(minutes=25 * i))
+
+    controller.terminate()
+    actual = controller.await_termination()
+    expected_results = [
+        {'col1': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0, 'number_of_stuff_sum_24h': 0, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 0, 'number_of_stuff_max_2h': 0,
+         'number_of_stuff_max_24h': 0, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
+        {'col1': 1, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1, 'number_of_stuff_sum_24h': 1, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 1, 'number_of_stuff_max_2h': 1,
+         'number_of_stuff_max_24h': 1, 'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5, 'number_of_stuff_avg_24h': 0.5},
+        {'col1': 2, 'number_of_stuff_sum_1h': 3, 'number_of_stuff_sum_2h': 3, 'number_of_stuff_sum_24h': 3, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 2, 'number_of_stuff_max_2h': 2,
+         'number_of_stuff_max_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
+        {'col1': 3, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_min_1h': 1,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 3, 'number_of_stuff_max_2h': 3,
+         'number_of_stuff_max_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 1.5, 'number_of_stuff_avg_24h': 1.5},
+        {'col1': 4, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 10, 'number_of_stuff_sum_24h': 10, 'number_of_stuff_min_1h': 2,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 4, 'number_of_stuff_max_2h': 4,
+         'number_of_stuff_max_24h': 4, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
+        {'col1': 5, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 15, 'number_of_stuff_sum_24h': 15,
+         'number_of_stuff_min_1h': 3, 'number_of_stuff_min_2h': 1, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 5,
+         'number_of_stuff_max_2h': 5, 'number_of_stuff_max_24h': 5, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 3.0,
+         'number_of_stuff_avg_24h': 2.5},
+        {'col1': 6, 'number_of_stuff_sum_1h': 15, 'number_of_stuff_sum_2h': 20, 'number_of_stuff_sum_24h': 21,
+         'number_of_stuff_min_1h': 4, 'number_of_stuff_min_2h': 2, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 6,
+         'number_of_stuff_max_2h': 6, 'number_of_stuff_max_24h': 6, 'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 4.0,
+         'number_of_stuff_avg_24h': 3.0},
+        {'col1': 7, 'number_of_stuff_sum_1h': 18, 'number_of_stuff_sum_2h': 25, 'number_of_stuff_sum_24h': 28,
+         'number_of_stuff_min_1h': 5, 'number_of_stuff_min_2h': 3, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 7,
+         'number_of_stuff_max_2h': 7, 'number_of_stuff_max_24h': 7, 'number_of_stuff_avg_1h': 6.0, 'number_of_stuff_avg_2h': 5.0,
+         'number_of_stuff_avg_24h': 3.5},
+        {'col1': 8, 'number_of_stuff_sum_1h': 21, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 36,
+         'number_of_stuff_min_1h': 6, 'number_of_stuff_min_2h': 4, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 8,
+         'number_of_stuff_max_2h': 8, 'number_of_stuff_max_24h': 8, 'number_of_stuff_avg_1h': 7.0, 'number_of_stuff_avg_2h': 6.0,
+         'number_of_stuff_avg_24h': 4.0},
+        {'col1': 9, 'number_of_stuff_sum_1h': 24, 'number_of_stuff_sum_2h': 35, 'number_of_stuff_sum_24h': 45,
+         'number_of_stuff_min_1h': 7, 'number_of_stuff_min_2h': 5, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9,
+         'number_of_stuff_max_2h': 9, 'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.0, 'number_of_stuff_avg_2h': 7.0,
+         'number_of_stuff_avg_24h': 4.5}
+    ]
+
+    assert actual == expected_results, \
+        f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
+
+    controller = build_flow([
+        Source(),
+        QueryAggregationByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
+                                               SlidingWindows(['1h', '2h', '24h'], '10m'))],
+                              setup_teardown_test),
+        Reduce([], lambda acc, x: append_return(acc, x)),
+    ]).run()
+
+    base_time = test_base_time + timedelta(minutes=25 * items_in_ingest_batch)
+    data = {'col1': items_in_ingest_batch}
+    controller.emit(data, 'tal', base_time)
+
+    controller.terminate()
+    actual = controller.await_termination()
+    expected_results = [
+        {'col1': 10, 'number_of_stuff_sum_1h': 17, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 45,
+         'number_of_stuff_min_1h': 8, 'number_of_stuff_min_2h': 6, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9,
+         'number_of_stuff_max_2h': 9, 'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.5, 'number_of_stuff_avg_2h': 7.5,
+         'number_of_stuff_avg_24h': 4.5}
+    ]
+
+    assert actual == expected_results, \
+        f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'

--- a/integration/test_aggregation_integration.py
+++ b/integration/test_aggregation_integration.py
@@ -12,7 +12,7 @@ from storey.dtypes import SlidingWindows
 test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
 
 
-def _generate_table_name(prefix='aggr_test'):
+def _generate_table_name(prefix='bigdata/aggr_test'):
     random_table = ''.join([random.choice(string.ascii_letters) for i in range(10)])
     return f'{prefix}/{random_table}'
 

--- a/storey/__init__.py
+++ b/storey/__init__.py
@@ -4,5 +4,5 @@ from .flow import (  # noqa: F401
     Filter, FlatMap, Flow, FlowError, JoinWithV3IOTable, JoinWithHttp, Map, Reduce, Source, NeedsV3ioAccess,
     MapWithState, WriteToV3IOStream, ReadCSV, Complete,
     HttpRequest, HttpResponse,
-    build_flow
+    build_flow, V3ioTable
 )

--- a/storey/__init__.py
+++ b/storey/__init__.py
@@ -4,5 +4,5 @@ from .flow import (  # noqa: F401
     Filter, FlatMap, Flow, FlowError, JoinWithV3IOTable, JoinWithHttp, Map, Reduce, Source, NeedsV3ioAccess,
     MapWithState, WriteToV3IOStream, ReadCSV, Complete,
     HttpRequest, HttpResponse,
-    build_flow, V3ioTable
+    build_flow
 )

--- a/storey/aggregation_utils.py
+++ b/storey/aggregation_utils.py
@@ -87,3 +87,21 @@ def get_dependant_aggregates(aggregate):
         if aggr_bits & raw_aggr == raw_aggr:
             aggrs.append(_all_aggregates_to_name[raw_aggr])
     return aggrs
+
+
+def get_all_raw_aggregates_with_hidden(aggregates):
+    raw_aggregates = {}
+
+    for aggregate in aggregates:
+        if is_raw_aggregate(aggregate):
+            raw_aggregates[aggregate] = False
+        else:
+            for dependant_aggr in get_dependant_aggregates(aggregate):
+                if dependant_aggr not in raw_aggregates:
+                    raw_aggregates[dependant_aggr] = True
+
+    return raw_aggregates
+
+
+def get_all_raw_aggregates(aggregates):
+    return set(get_all_raw_aggregates_with_hidden(aggregates).keys())

--- a/storey/aggregations.py
+++ b/storey/aggregations.py
@@ -191,7 +191,7 @@ class AggregateStore:
 
         key_to_aggregate = await self._get_or_load_key(key, timestamp)
         key_to_aggregate.aggregate(data, timestamp)
-        await self._save_store()
+        await self._save_key(key)
 
     async def get_features(self, key, timestamp):
         if not self.schema:
@@ -270,6 +270,9 @@ class AggregateStore:
 
     async def _save_store(self):
         await self._table.save_store(self.cache)
+
+    async def _save_key(self, key):
+        await self._table.save_key(key, self.cache[key])
 
     def _aggregates_to_schema(self):
         schema = {}

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -744,7 +744,7 @@ class V3ioTable(NeedsV3ioAccess):
 
         return data
 
-    def load_store(self):
+    async def load_store(self):
         pass
 
     # Loads a specific key from the store, and returns it in the following format

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -767,7 +767,7 @@ class V3ioTable(NeedsV3ioAccess):
             elif response.status == 200:
                 parsed_response = _v3io_parse_get_item_response(body)
                 for name, blob in parsed_response.items():
-                    parsed_response[name] = pickle.loads(parsed_response[name])
+                    parsed_response[name] = pickle.loads(blob)
 
                 return parsed_response
             else:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -335,6 +335,11 @@ class NeedsV3ioAccess:
             'X-v3io-session-key': access_key
         }
 
+        self._update_item_headers = {
+            'X-v3io-function': 'UpdateItem',
+            'X-v3io-session-key': access_key
+        }
+
         self._put_records_headers = {
             'X-v3io-function': 'PutRecords',
             'X-v3io-session-key': access_key
@@ -357,6 +362,10 @@ class NeedsV3ioAccess:
 
         self._get_records_headers = {
             'X-v3io-function': 'GetRecords',
+            'X-v3io-session-key': access_key
+        }
+
+        self._get_put_file_headers = {
             'X-v3io-session-key': access_key
         }
 

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -681,7 +681,7 @@ class V3ioTable(NeedsV3ioAccess):
             self.lazy_init()
 
         response = await self.client_session.put(f'{self._webapi_url}/{self.table}/{schema_file_name}',
-                                            headers=self._get_put_file_headers, data=json.dumps(schema), ssl=False)
+                                                 headers=self._get_put_file_headers, data=json.dumps(schema), ssl=False)
         if not response.status == 200:
             body = await response.text()
             raise V3ioError(f'Failed to save schema file. Response status code was {response.status}: {body}')
@@ -712,7 +712,7 @@ class V3ioTable(NeedsV3ioAccess):
         for key, aggregation_element in aggr_store.items():
             data = {'Item': self._get_attributes_as_blob(aggregation_element), 'UpdateMode': 'CreateOrReplaceAttributes'}
             response = await self.client_session.put(f'{self._webapi_url}/{self.table}/{key}',
-                                                headers=self._put_item_headers, data=json.dumps(data), ssl=False)
+                                                     headers=self._put_item_headers, data=json.dumps(data), ssl=False)
             if not response.status == 200:
                 body = await response.text()
                 raise V3ioError(f'Failed to save aggregation for key: {key}. Response status code was {response.status}: {body}')
@@ -723,7 +723,7 @@ class V3ioTable(NeedsV3ioAccess):
 
         data = {'Item': self._get_attributes_as_blob(aggr_item), 'UpdateMode': 'CreateOrReplaceAttributes'}
         response = await self.client_session.put(f'{self._webapi_url}/{self.table}/{key}',
-                                            headers=self._put_item_headers, data=json.dumps(data), ssl=False)
+                                                 headers=self._put_item_headers, data=json.dumps(data), ssl=False)
         if not response.status == 200:
             body = await response.text()
             raise V3ioError(f'Failed to save aggregation for key: {key}. Response status code was {response.status}: {body}')
@@ -750,7 +750,7 @@ class V3ioTable(NeedsV3ioAccess):
         request_body = json.dumps({'AttributesToGet': '*'})
 
         response = await self.client_session.put(f'{self._webapi_url}/{self.table}/{key}',
-                                            headers=self._get_item_headers, data=request_body, ssl=False)
+                                                 headers=self._get_item_headers, data=request_body, ssl=False)
         body = await response.text()
         if response.status == 404:
             return None

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -664,7 +664,6 @@ class V3ioTable(NeedsV3ioAccess):
             await client_session.close()
 
         return schema
-        pass
 
     async def load_schema(self):
         connector = aiohttp.TCPConnector()
@@ -700,7 +699,6 @@ class V3ioTable(NeedsV3ioAccess):
                 raise V3ioError(f'Failed to save schema file. Response status code was {response.status}: {body}')
 
         await client_session.close()
-        pass
 
     def _get_attributes_as_blob(self, aggregation_element):
         data = {}

--- a/storey/utils.py
+++ b/storey/utils.py
@@ -3,6 +3,7 @@ import struct
 from array import array
 
 bucketPerWindow = 10
+schema_file_name = '.schema'
 
 
 def parse_duration(string_time):

--- a/tests/test_aggregate_by_key.py
+++ b/tests/test_aggregate_by_key.py
@@ -17,7 +17,10 @@ class MockTable:
     async def save_store(self, aggr_store):
         pass
 
-    def load_store(self):
+    async def save_key(self, key, aggr_item):
+        pass
+
+    async def load_store(self):
         pass
 
     async def load_key(self, key):

--- a/tests/test_aggregate_by_key.py
+++ b/tests/test_aggregate_by_key.py
@@ -7,26 +7,6 @@ from storey.dtypes import SlidingWindows, FixedWindows, EmitAfterMaxEvent
 test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
 
 
-class MockTable:
-    async def save_schema(self, schema):
-        pass
-
-    async def load_schema(self):
-        pass
-
-    async def save_store(self, aggr_store):
-        pass
-
-    async def save_key(self, key, aggr_item):
-        pass
-
-    async def load_store(self):
-        pass
-
-    async def load_key(self, key):
-        pass
-
-
 def append_return(lst, x):
     lst.append(x)
     return lst
@@ -37,7 +17,7 @@ def test_sliding_window_simple_aggregation_flow():
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       MockTable()),
+                       'noop', 'test'),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -89,7 +69,7 @@ def test_sliding_window_multiple_keys_aggregation_flow():
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       MockTable()),
+                       'noop', 'test'),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -131,7 +111,7 @@ def test_sliding_window_aggregations_with_filters_flow():
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'),
                                         aggr_filter=lambda element: element['is_valid'] == 0)],
-                       MockTable()),
+                       'noop', 'test'),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -182,7 +162,7 @@ def test_sliding_window_aggregations_with_max_values_flow():
         AggregateByKey([FieldAggregator("num_hours_with_stuff_in_the_last_24h", "col1", ["count"],
                                         SlidingWindows(['24h'], '1h'),
                                         max_value=1)],
-                       MockTable()),
+                       'noop', 'test'),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -216,7 +196,7 @@ def test_sliding_window_simple_aggregation_flow_multiple_fields():
                                         SlidingWindows(['1h', '2h'], '15m')),
                         FieldAggregator("abc", "col3", ["sum"],
                                         SlidingWindows(['24h'], '10m'))],
-                       MockTable()),
+                       'noop', 'test'),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -269,7 +249,7 @@ def test_fixed_window_simple_aggregation_flow():
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["count"],
                                         FixedWindows(['1h', '2h', '3h', '24h']))],
-                       MockTable()),
+                       'noop', 'test'),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -309,7 +289,7 @@ def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow():
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       MockTable(), emit_policy=EmitAfterMaxEvent(3)),
+                       'noop', 'test', emit_policy=EmitAfterMaxEvent(3)),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 

--- a/tests/test_aggregate_by_key.py
+++ b/tests/test_aggregate_by_key.py
@@ -20,6 +20,23 @@ def _delete_dir(path):
     pass
 
 
+class MockTable:
+    async def save_schema(self, schema):
+        pass
+
+    async def load_schema(self):
+        pass
+
+    async def save_store(self, aggr_store):
+        pass
+
+    def load_store(self):
+        pass
+
+    async def load_key(self, key):
+        pass
+
+
 @pytest.fixture()
 def setup_teardown_test():
     table_name = _generate_table_name()
@@ -32,12 +49,12 @@ def append_return(lst, x):
     return lst
 
 
-def test_sliding_window_simple_aggregation_flow(setup_teardown_test):
+def test_sliding_window_simple_aggregation_flow():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       V3ioTable(setup_teardown_test)),
+                       MockTable()),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -84,12 +101,12 @@ def test_sliding_window_simple_aggregation_flow(setup_teardown_test):
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_multiple_keys_aggregation_flow(setup_teardown_test):
+def test_sliding_window_multiple_keys_aggregation_flow():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       V3ioTable(setup_teardown_test)),
+                       MockTable()),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -125,13 +142,13 @@ def test_sliding_window_multiple_keys_aggregation_flow(setup_teardown_test):
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_aggregations_with_filters_flow(setup_teardown_test):
+def test_sliding_window_aggregations_with_filters_flow():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'),
                                         aggr_filter=lambda element: element['is_valid'] == 0)],
-                       V3ioTable(setup_teardown_test)),
+                       MockTable()),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -176,13 +193,13 @@ def test_sliding_window_aggregations_with_filters_flow(setup_teardown_test):
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_aggregations_with_max_values_flow(setup_teardown_test):
+def test_sliding_window_aggregations_with_max_values_flow():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("num_hours_with_stuff_in_the_last_24h", "col1", ["count"],
                                         SlidingWindows(['24h'], '1h'),
                                         max_value=1)],
-                       V3ioTable(setup_teardown_test)),
+                       MockTable()),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -207,7 +224,7 @@ def test_sliding_window_aggregations_with_max_values_flow(setup_teardown_test):
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_simple_aggregation_flow_multiple_fields(setup_teardown_test):
+def test_sliding_window_simple_aggregation_flow_multiple_fields():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
@@ -216,7 +233,7 @@ def test_sliding_window_simple_aggregation_flow_multiple_fields(setup_teardown_t
                                         SlidingWindows(['1h', '2h'], '15m')),
                         FieldAggregator("abc", "col3", ["sum"],
                                         SlidingWindows(['24h'], '10m'))],
-                       V3ioTable(setup_teardown_test)),
+                       MockTable()),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -264,12 +281,12 @@ def test_sliding_window_simple_aggregation_flow_multiple_fields(setup_teardown_t
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_fixed_window_simple_aggregation_flow(setup_teardown_test):
+def test_fixed_window_simple_aggregation_flow():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["count"],
                                         FixedWindows(['1h', '2h', '3h', '24h']))],
-                       V3ioTable(setup_teardown_test)),
+                       MockTable()),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -304,12 +321,12 @@ def test_fixed_window_simple_aggregation_flow(setup_teardown_test):
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow(setup_teardown_test):
+def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow():
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       V3ioTable(setup_teardown_test), emit_policy=EmitAfterMaxEvent(3)),
+                       MockTable(), emit_policy=EmitAfterMaxEvent(3)),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 

--- a/tests/test_aggregate_by_key.py
+++ b/tests/test_aggregate_by_key.py
@@ -1,10 +1,30 @@
 from datetime import datetime, timedelta
-
-from storey import build_flow, Source, Reduce
-from storey.aggregations import AggregateByKey, FieldAggregator
+import asyncio
+import random
+import string
+from storey import build_flow, Source, Reduce, Map
+from storey.aggregations import AggregateByKey, FieldAggregator, AggregateStore, QueryAggregateByKey
 from storey.dtypes import SlidingWindows, FixedWindows, EmitAfterMaxEvent
+import pytest
 
 test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
+
+
+def _generate_table_name(prefix='aggr_test'):
+    random_table = ''.join([random.choice(string.ascii_letters) for i in range(10)])
+    return f'{prefix}/{random_table}'
+
+
+def _delete_dir(path):
+    print('todo - delete:', path)
+    pass
+
+
+@pytest.fixture()
+def setup_teardown_test():
+    table_name = _generate_table_name()
+    yield table_name
+    _delete_dir(table_name)
 
 
 def append_return(lst, x):
@@ -12,12 +32,12 @@ def append_return(lst, x):
     return lst
 
 
-def test_sliding_window_simple_aggregation_flow():
+def test_sliding_window_simple_aggregation_flow(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       'table'),
+                       setup_teardown_test),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -28,44 +48,34 @@ def test_sliding_window_simple_aggregation_flow():
     controller.terminate()
     actual = controller.await_termination()
     expected_results = [
-        {'col1': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0, 'number_of_stuff_sum_24h': 0, 'number_of_stuff_count_1h': 1,
-         'number_of_stuff_count_2h': 1, 'number_of_stuff_count_24h': 1, 'number_of_stuff_min_1h': 0, 'number_of_stuff_min_2h': 0,
-         'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 0, 'number_of_stuff_max_2h': 0, 'number_of_stuff_max_24h': 0,
-         'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
-        {'col1': 1, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1, 'number_of_stuff_sum_24h': 1, 'number_of_stuff_count_1h': 2,
-         'number_of_stuff_count_2h': 2, 'number_of_stuff_count_24h': 2, 'number_of_stuff_min_1h': 0, 'number_of_stuff_min_2h': 0,
-         'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 1, 'number_of_stuff_max_2h': 1, 'number_of_stuff_max_24h': 1,
-         'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5, 'number_of_stuff_avg_24h': 0.5},
-        {'col1': 2, 'number_of_stuff_sum_1h': 3, 'number_of_stuff_sum_2h': 3, 'number_of_stuff_sum_24h': 3, 'number_of_stuff_count_1h': 3,
-         'number_of_stuff_count_2h': 3, 'number_of_stuff_count_24h': 3, 'number_of_stuff_min_1h': 0, 'number_of_stuff_min_2h': 0,
-         'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 2, 'number_of_stuff_max_2h': 2, 'number_of_stuff_max_24h': 2,
-         'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
-        {'col1': 3, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_count_1h': 3,
-         'number_of_stuff_count_2h': 4, 'number_of_stuff_count_24h': 4, 'number_of_stuff_min_1h': 1, 'number_of_stuff_min_2h': 0,
-         'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 3, 'number_of_stuff_max_2h': 3, 'number_of_stuff_max_24h': 3,
-         'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 1.5, 'number_of_stuff_avg_24h': 1.5},
-        {'col1': 4, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 10, 'number_of_stuff_sum_24h': 10, 'number_of_stuff_count_1h': 3,
-         'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 5, 'number_of_stuff_min_1h': 2, 'number_of_stuff_min_2h': 0,
-         'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 4, 'number_of_stuff_max_2h': 4, 'number_of_stuff_max_24h': 4,
-         'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
-        {'col1': 5, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 15, 'number_of_stuff_sum_24h': 15,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 6, 'number_of_stuff_min_1h': 3,
+        {'col1': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0, 'number_of_stuff_sum_24h': 0, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 0, 'number_of_stuff_max_2h': 0,
+         'number_of_stuff_max_24h': 0, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
+        {'col1': 1, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1, 'number_of_stuff_sum_24h': 1, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 1, 'number_of_stuff_max_2h': 1,
+         'number_of_stuff_max_24h': 1, 'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5, 'number_of_stuff_avg_24h': 0.5},
+        {'col1': 2, 'number_of_stuff_sum_1h': 3, 'number_of_stuff_sum_2h': 3, 'number_of_stuff_sum_24h': 3, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 2, 'number_of_stuff_max_2h': 2,
+         'number_of_stuff_max_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
+        {'col1': 3, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_min_1h': 1,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 3, 'number_of_stuff_max_2h': 3,
+         'number_of_stuff_max_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 1.5, 'number_of_stuff_avg_24h': 1.5},
+        {'col1': 4, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 10, 'number_of_stuff_sum_24h': 10, 'number_of_stuff_min_1h': 2,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 4, 'number_of_stuff_max_2h': 4,
+         'number_of_stuff_max_24h': 4, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
+        {'col1': 5, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 15, 'number_of_stuff_sum_24h': 15, 'number_of_stuff_min_1h': 3,
          'number_of_stuff_min_2h': 1, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 5, 'number_of_stuff_max_2h': 5,
          'number_of_stuff_max_24h': 5, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 3.0, 'number_of_stuff_avg_24h': 2.5},
-        {'col1': 6, 'number_of_stuff_sum_1h': 15, 'number_of_stuff_sum_2h': 20, 'number_of_stuff_sum_24h': 21,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 7, 'number_of_stuff_min_1h': 4,
+        {'col1': 6, 'number_of_stuff_sum_1h': 15, 'number_of_stuff_sum_2h': 20, 'number_of_stuff_sum_24h': 21, 'number_of_stuff_min_1h': 4,
          'number_of_stuff_min_2h': 2, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 6, 'number_of_stuff_max_2h': 6,
          'number_of_stuff_max_24h': 6, 'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 4.0, 'number_of_stuff_avg_24h': 3.0},
-        {'col1': 7, 'number_of_stuff_sum_1h': 18, 'number_of_stuff_sum_2h': 25, 'number_of_stuff_sum_24h': 28,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 8, 'number_of_stuff_min_1h': 5,
+        {'col1': 7, 'number_of_stuff_sum_1h': 18, 'number_of_stuff_sum_2h': 25, 'number_of_stuff_sum_24h': 28, 'number_of_stuff_min_1h': 5,
          'number_of_stuff_min_2h': 3, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 7, 'number_of_stuff_max_2h': 7,
          'number_of_stuff_max_24h': 7, 'number_of_stuff_avg_1h': 6.0, 'number_of_stuff_avg_2h': 5.0, 'number_of_stuff_avg_24h': 3.5},
-        {'col1': 8, 'number_of_stuff_sum_1h': 21, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 36,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 9, 'number_of_stuff_min_1h': 6,
+        {'col1': 8, 'number_of_stuff_sum_1h': 21, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 36, 'number_of_stuff_min_1h': 6,
          'number_of_stuff_min_2h': 4, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 8, 'number_of_stuff_max_2h': 8,
          'number_of_stuff_max_24h': 8, 'number_of_stuff_avg_1h': 7.0, 'number_of_stuff_avg_2h': 6.0, 'number_of_stuff_avg_24h': 4.0},
-        {'col1': 9, 'number_of_stuff_sum_1h': 24, 'number_of_stuff_sum_2h': 35, 'number_of_stuff_sum_24h': 45,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 10, 'number_of_stuff_min_1h': 7,
+        {'col1': 9, 'number_of_stuff_sum_1h': 24, 'number_of_stuff_sum_2h': 35, 'number_of_stuff_sum_24h': 45, 'number_of_stuff_min_1h': 7,
          'number_of_stuff_min_2h': 5, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9, 'number_of_stuff_max_2h': 9,
          'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.0, 'number_of_stuff_avg_2h': 7.0, 'number_of_stuff_avg_24h': 4.5}
     ]
@@ -74,12 +84,12 @@ def test_sliding_window_simple_aggregation_flow():
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_multiple_keys_aggregation_flow():
+def test_sliding_window_multiple_keys_aggregation_flow(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       'table'),
+                       setup_teardown_test),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -91,47 +101,37 @@ def test_sliding_window_multiple_keys_aggregation_flow():
     actual = controller.await_termination()
     expected_results = [
         {'col1': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0, 'number_of_stuff_sum_24h': 0,
-         'number_of_stuff_count_1h': 1, 'number_of_stuff_count_2h': 1, 'number_of_stuff_count_24h': 1,
          'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
         {'col1': 1, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1, 'number_of_stuff_sum_24h': 1,
-         'number_of_stuff_count_1h': 1, 'number_of_stuff_count_2h': 1, 'number_of_stuff_count_24h': 1,
          'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
         {'col1': 2, 'number_of_stuff_sum_1h': 2, 'number_of_stuff_sum_2h': 2, 'number_of_stuff_sum_24h': 2,
-         'number_of_stuff_count_1h': 2, 'number_of_stuff_count_2h': 2, 'number_of_stuff_count_24h': 2,
          'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
         {'col1': 3, 'number_of_stuff_sum_1h': 4, 'number_of_stuff_sum_2h': 4, 'number_of_stuff_sum_24h': 4,
-         'number_of_stuff_count_1h': 2, 'number_of_stuff_count_2h': 2, 'number_of_stuff_count_24h': 2,
          'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
         {'col1': 4, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 3, 'number_of_stuff_count_24h': 3,
          'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
         {'col1': 5, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 9, 'number_of_stuff_sum_24h': 9,
-         'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 3, 'number_of_stuff_count_24h': 3,
          'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0, 'number_of_stuff_avg_24h': 3.0},
         {'col1': 6, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 12, 'number_of_stuff_sum_24h': 12,
-         'number_of_stuff_count_1h': 4, 'number_of_stuff_count_2h': 4, 'number_of_stuff_count_24h': 4,
          'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0, 'number_of_stuff_avg_24h': 3.0},
         {'col1': 7, 'number_of_stuff_sum_1h': 16, 'number_of_stuff_sum_2h': 16, 'number_of_stuff_sum_24h': 16,
-         'number_of_stuff_count_1h': 4, 'number_of_stuff_count_2h': 4, 'number_of_stuff_count_24h': 4,
          'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0, 'number_of_stuff_avg_24h': 4.0},
         {'col1': 8, 'number_of_stuff_sum_1h': 20, 'number_of_stuff_sum_2h': 20, 'number_of_stuff_sum_24h': 20,
-         'number_of_stuff_count_1h': 5, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 5,
          'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0, 'number_of_stuff_avg_24h': 4.0},
         {'col1': 9, 'number_of_stuff_sum_1h': 25, 'number_of_stuff_sum_2h': 25, 'number_of_stuff_sum_24h': 25,
-         'number_of_stuff_count_1h': 5, 'number_of_stuff_count_2h': 5, 'number_of_stuff_count_24h': 5,
          'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 5.0, 'number_of_stuff_avg_24h': 5.0}]
 
     assert actual == expected_results, \
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_aggregations_with_filters_flow():
+def test_sliding_window_aggregations_with_filters_flow(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'),
                                         aggr_filter=lambda element: element['is_valid'] == 0)],
-                       'table'),
+                       setup_teardown_test),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -142,57 +142,47 @@ def test_sliding_window_aggregations_with_filters_flow():
     controller.terminate()
     actual = controller.await_termination()
     expected_results = [{'col1': 0, 'is_valid': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0,
-                         'number_of_stuff_sum_24h': 0, 'number_of_stuff_count_1h': 1, 'number_of_stuff_count_2h': 1,
-                         'number_of_stuff_count_24h': 1, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0,
+                         'number_of_stuff_sum_24h': 0, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0,
                          'number_of_stuff_avg_24h': 0.0},
                         {'col1': 1, 'is_valid': 1, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0,
-                         'number_of_stuff_sum_24h': 0, 'number_of_stuff_count_1h': 1, 'number_of_stuff_count_2h': 1,
-                         'number_of_stuff_count_24h': 1, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0,
+                         'number_of_stuff_sum_24h': 0, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0,
                          'number_of_stuff_avg_24h': 0.0},
                         {'col1': 2, 'is_valid': 0, 'number_of_stuff_sum_1h': 2, 'number_of_stuff_sum_2h': 2,
-                         'number_of_stuff_sum_24h': 2, 'number_of_stuff_count_1h': 2, 'number_of_stuff_count_2h': 2,
-                         'number_of_stuff_count_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0,
+                         'number_of_stuff_sum_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0,
                          'number_of_stuff_avg_24h': 1.0},
                         {'col1': 3, 'is_valid': 1, 'number_of_stuff_sum_1h': 2, 'number_of_stuff_sum_2h': 2,
-                         'number_of_stuff_sum_24h': 2, 'number_of_stuff_count_1h': 2, 'number_of_stuff_count_2h': 2,
-                         'number_of_stuff_count_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0,
+                         'number_of_stuff_sum_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0,
                          'number_of_stuff_avg_24h': 1.0},
                         {'col1': 4, 'is_valid': 0, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6,
-                         'number_of_stuff_sum_24h': 6, 'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 3,
-                         'number_of_stuff_count_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0,
+                         'number_of_stuff_sum_24h': 6, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0,
                          'number_of_stuff_avg_24h': 2.0},
                         {'col1': 5, 'is_valid': 1, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6,
-                         'number_of_stuff_sum_24h': 6, 'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 3,
-                         'number_of_stuff_count_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0,
+                         'number_of_stuff_sum_24h': 6, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0,
                          'number_of_stuff_avg_24h': 2.0},
                         {'col1': 6, 'is_valid': 0, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 12,
-                         'number_of_stuff_sum_24h': 12, 'number_of_stuff_count_1h': 4, 'number_of_stuff_count_2h': 4,
-                         'number_of_stuff_count_24h': 4, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0,
+                         'number_of_stuff_sum_24h': 12, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0,
                          'number_of_stuff_avg_24h': 3.0},
                         {'col1': 7, 'is_valid': 1, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 12,
-                         'number_of_stuff_sum_24h': 12, 'number_of_stuff_count_1h': 4, 'number_of_stuff_count_2h': 4,
-                         'number_of_stuff_count_24h': 4, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0,
+                         'number_of_stuff_sum_24h': 12, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0,
                          'number_of_stuff_avg_24h': 3.0},
                         {'col1': 8, 'is_valid': 0, 'number_of_stuff_sum_1h': 20, 'number_of_stuff_sum_2h': 20,
-                         'number_of_stuff_sum_24h': 20, 'number_of_stuff_count_1h': 5, 'number_of_stuff_count_2h': 5,
-                         'number_of_stuff_count_24h': 5, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0,
+                         'number_of_stuff_sum_24h': 20, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0,
                          'number_of_stuff_avg_24h': 4.0},
                         {'col1': 9, 'is_valid': 1, 'number_of_stuff_sum_1h': 20, 'number_of_stuff_sum_2h': 20,
-                         'number_of_stuff_sum_24h': 20, 'number_of_stuff_count_1h': 5, 'number_of_stuff_count_2h': 5,
-                         'number_of_stuff_count_24h': 5, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0,
+                         'number_of_stuff_sum_24h': 20, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0,
                          'number_of_stuff_avg_24h': 4.0}]
 
     assert actual == expected_results, \
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_aggregations_with_max_values_flow():
+def test_sliding_window_aggregations_with_max_values_flow(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("num_hours_with_stuff_in_the_last_24h", "col1", ["count"],
                                         SlidingWindows(['24h'], '1h'),
                                         max_value=1)],
-                       'table'),
+                       setup_teardown_test),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -217,7 +207,7 @@ def test_sliding_window_aggregations_with_max_values_flow():
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_sliding_window_simple_aggregation_flow_multiple_fields():
+def test_sliding_window_simple_aggregation_flow_multiple_fields(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
@@ -226,7 +216,7 @@ def test_sliding_window_simple_aggregation_flow_multiple_fields():
                                         SlidingWindows(['1h', '2h'], '15m')),
                         FieldAggregator("abc", "col3", ["sum"],
                                         SlidingWindows(['24h'], '10m'))],
-                       'table'),
+                       setup_teardown_test),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -237,53 +227,36 @@ def test_sliding_window_simple_aggregation_flow_multiple_fields():
     controller.terminate()
     actual = controller.await_termination()
     expected_results = [{'col1': 0, 'col2': 0.0, 'col3': 4, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0,
-                         'number_of_stuff_sum_24h': 0, 'number_of_stuff_count_1h': 1, 'number_of_stuff_count_2h': 1,
-                         'number_of_stuff_count_24h': 1, 'number_of_things_count_1h': 1, 'number_of_things_count_2h': 1,
-                         'abc_sum_24h': 4, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0,
-                         'number_of_stuff_avg_24h': 0.0},
+                         'number_of_stuff_sum_24h': 0, 'number_of_things_count_1h': 1, 'number_of_things_count_2h': 1,
+                         'abc_sum_24h': 4, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
                         {'col1': 1, 'col2': 1.2, 'col3': 6, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1,
-                         'number_of_stuff_sum_24h': 1, 'number_of_stuff_count_1h': 2, 'number_of_stuff_count_2h': 2,
-                         'number_of_stuff_count_24h': 2, 'number_of_things_count_1h': 2, 'number_of_things_count_2h': 2,
-                         'abc_sum_24h': 10, 'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5,
-                         'number_of_stuff_avg_24h': 0.5},
+                         'number_of_stuff_sum_24h': 1, 'number_of_things_count_1h': 2, 'number_of_things_count_2h': 2,
+                         'abc_sum_24h': 10, 'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5, 'number_of_stuff_avg_24h': 0.5},
                         {'col1': 2, 'col2': 2.4, 'col3': 8, 'number_of_stuff_sum_1h': 3, 'number_of_stuff_sum_2h': 3,
-                         'number_of_stuff_sum_24h': 3, 'number_of_stuff_count_1h': 3, 'number_of_stuff_count_2h': 3,
-                         'number_of_stuff_count_24h': 3, 'number_of_things_count_1h': 3, 'number_of_things_count_2h': 3,
-                         'abc_sum_24h': 18, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0,
-                         'number_of_stuff_avg_24h': 1.0},
+                         'number_of_stuff_sum_24h': 3, 'number_of_things_count_1h': 3, 'number_of_things_count_2h': 3,
+                         'abc_sum_24h': 18, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
                         {'col1': 3, 'col2': 3.5999999999999996, 'col3': 10, 'number_of_stuff_sum_1h': 6,
-                         'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_count_1h': 4,
-                         'number_of_stuff_count_2h': 4, 'number_of_stuff_count_24h': 4, 'number_of_things_count_1h': 4,
-                         'number_of_things_count_2h': 4, 'abc_sum_24h': 28, 'number_of_stuff_avg_1h': 1.5,
-                         'number_of_stuff_avg_2h': 1.5, 'number_of_stuff_avg_24h': 1.5},
+                         'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_things_count_1h': 4,
+                         'number_of_things_count_2h': 4, 'abc_sum_24h': 28, 'number_of_stuff_avg_1h': 1.5, 'number_of_stuff_avg_2h': 1.5,
+                         'number_of_stuff_avg_24h': 1.5},
                         {'col1': 4, 'col2': 4.8, 'col3': 12, 'number_of_stuff_sum_1h': 10, 'number_of_stuff_sum_2h': 10,
-                         'number_of_stuff_sum_24h': 10, 'number_of_stuff_count_1h': 5, 'number_of_stuff_count_2h': 5,
-                         'number_of_stuff_count_24h': 5, 'number_of_things_count_1h': 5, 'number_of_things_count_2h': 5,
-                         'abc_sum_24h': 40, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0,
-                         'number_of_stuff_avg_24h': 2.0},
+                         'number_of_stuff_sum_24h': 10, 'number_of_things_count_1h': 5, 'number_of_things_count_2h': 5,
+                         'abc_sum_24h': 40, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
                         {'col1': 5, 'col2': 6.0, 'col3': 14, 'number_of_stuff_sum_1h': 15, 'number_of_stuff_sum_2h': 15,
-                         'number_of_stuff_sum_24h': 15, 'number_of_stuff_count_1h': 6, 'number_of_stuff_count_2h': 6,
-                         'number_of_stuff_count_24h': 6, 'number_of_things_count_1h': 6, 'number_of_things_count_2h': 6,
-                         'abc_sum_24h': 54, 'number_of_stuff_avg_1h': 2.5, 'number_of_stuff_avg_2h': 2.5,
-                         'number_of_stuff_avg_24h': 2.5},
+                         'number_of_stuff_sum_24h': 15, 'number_of_things_count_1h': 6, 'number_of_things_count_2h': 6,
+                         'abc_sum_24h': 54, 'number_of_stuff_avg_1h': 2.5, 'number_of_stuff_avg_2h': 2.5, 'number_of_stuff_avg_24h': 2.5},
                         {'col1': 6, 'col2': 7.199999999999999, 'col3': 16, 'number_of_stuff_sum_1h': 21,
-                         'number_of_stuff_sum_2h': 21, 'number_of_stuff_sum_24h': 21, 'number_of_stuff_count_1h': 7,
-                         'number_of_stuff_count_2h': 7, 'number_of_stuff_count_24h': 7, 'number_of_things_count_1h': 7,
+                         'number_of_stuff_sum_2h': 21, 'number_of_stuff_sum_24h': 21, 'number_of_things_count_1h': 7,
                          'number_of_things_count_2h': 7, 'abc_sum_24h': 70, 'number_of_stuff_avg_1h': 3.0,
                          'number_of_stuff_avg_2h': 3.0, 'number_of_stuff_avg_24h': 3.0},
                         {'col1': 7, 'col2': 8.4, 'col3': 18, 'number_of_stuff_sum_1h': 28, 'number_of_stuff_sum_2h': 28,
-                         'number_of_stuff_sum_24h': 28, 'number_of_stuff_count_1h': 8, 'number_of_stuff_count_2h': 8,
-                         'number_of_stuff_count_24h': 8, 'number_of_things_count_1h': 8, 'number_of_things_count_2h': 8,
-                         'abc_sum_24h': 88, 'number_of_stuff_avg_1h': 3.5, 'number_of_stuff_avg_2h': 3.5,
-                         'number_of_stuff_avg_24h': 3.5},
+                         'number_of_stuff_sum_24h': 28, 'number_of_things_count_1h': 8, 'number_of_things_count_2h': 8,
+                         'abc_sum_24h': 88, 'number_of_stuff_avg_1h': 3.5, 'number_of_stuff_avg_2h': 3.5, 'number_of_stuff_avg_24h': 3.5},
                         {'col1': 8, 'col2': 9.6, 'col3': 20, 'number_of_stuff_sum_1h': 36, 'number_of_stuff_sum_2h': 36,
-                         'number_of_stuff_sum_24h': 36, 'number_of_stuff_count_1h': 9, 'number_of_stuff_count_2h': 9,
-                         'number_of_stuff_count_24h': 9, 'number_of_things_count_1h': 9, 'number_of_things_count_2h': 9,
-                         'abc_sum_24h': 108, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0,
-                         'number_of_stuff_avg_24h': 4.0},
+                         'number_of_stuff_sum_24h': 36, 'number_of_things_count_1h': 9, 'number_of_things_count_2h': 9,
+                         'abc_sum_24h': 108, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 4.0, 'number_of_stuff_avg_24h': 4.0},
                         {'col1': 9, 'col2': 10.799999999999999, 'col3': 22, 'number_of_stuff_sum_1h': 45,
-                         'number_of_stuff_sum_2h': 45, 'number_of_stuff_sum_24h': 45, 'number_of_stuff_count_1h': 10,
-                         'number_of_stuff_count_2h': 10, 'number_of_stuff_count_24h': 10,
+                         'number_of_stuff_sum_2h': 45, 'number_of_stuff_sum_24h': 45,
                          'number_of_things_count_1h': 10, 'number_of_things_count_2h': 10, 'abc_sum_24h': 130,
                          'number_of_stuff_avg_1h': 4.5, 'number_of_stuff_avg_2h': 4.5, 'number_of_stuff_avg_24h': 4.5}]
 
@@ -291,12 +264,12 @@ def test_sliding_window_simple_aggregation_flow_multiple_fields():
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_fixed_window_simple_aggregation_flow():
+def test_fixed_window_simple_aggregation_flow(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["count"],
                                         FixedWindows(['1h', '2h', '3h', '24h']))],
-                       'table'),
+                       setup_teardown_test),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -331,12 +304,12 @@ def test_fixed_window_simple_aggregation_flow():
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
 
 
-def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow():
+def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow(setup_teardown_test):
     controller = build_flow([
         Source(),
         AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
                                         SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       'table', emit_policy=EmitAfterMaxEvent(3)),
+                       setup_teardown_test, emit_policy=EmitAfterMaxEvent(3)),
         Reduce([], lambda acc, x: append_return(acc, x)),
     ]).run()
 
@@ -347,18 +320,115 @@ def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow():
     controller.terminate()
     actual = controller.await_termination()
     expected_results = [
-        {'col1': 4, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_count_1h': 3,
-         'number_of_stuff_count_2h': 3, 'number_of_stuff_count_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 2.0,
-         'number_of_stuff_avg_24h': 2.0},
-        {'col1': 5, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 9, 'number_of_stuff_sum_24h': 9, 'number_of_stuff_count_1h': 3,
-         'number_of_stuff_count_2h': 3, 'number_of_stuff_count_24h': 3, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 3.0,
-         'number_of_stuff_avg_24h': 3.0},
+        {'col1': 4, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_avg_1h': 2.0,
+         'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
+        {'col1': 5, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 9, 'number_of_stuff_sum_24h': 9, 'number_of_stuff_avg_1h': 3.0,
+         'number_of_stuff_avg_2h': 3.0, 'number_of_stuff_avg_24h': 3.0},
         {'col1': 10, 'number_of_stuff_sum_1h': 30, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 30,
-         'number_of_stuff_count_1h': 6, 'number_of_stuff_count_2h': 6, 'number_of_stuff_count_24h': 6, 'number_of_stuff_avg_1h': 5.0,
-         'number_of_stuff_avg_2h': 5.0, 'number_of_stuff_avg_24h': 5.0},
+         'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 5.0, 'number_of_stuff_avg_24h': 5.0},
         {'col1': 11, 'number_of_stuff_sum_1h': 36, 'number_of_stuff_sum_2h': 36, 'number_of_stuff_sum_24h': 36,
-         'number_of_stuff_count_1h': 6, 'number_of_stuff_count_2h': 6, 'number_of_stuff_count_24h': 6, 'number_of_stuff_avg_1h': 6.0,
-         'number_of_stuff_avg_2h': 6.0, 'number_of_stuff_avg_24h': 6.0}]
+         'number_of_stuff_avg_1h': 6.0, 'number_of_stuff_avg_2h': 6.0, 'number_of_stuff_avg_24h': 6.0}]
+
+    assert actual == expected_results, \
+        f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
+
+
+def test_t():
+    asyncio.run(test_tal())
+
+
+async def test_tal():
+    store = AggregateStore([FieldAggregator("number_of_stuff", "col1", ["sum", "avg"],
+                                            SlidingWindows(['1h', '2h', '24h'], '10m')),
+                            FieldAggregator("number_of_things", "col2", ["count"],
+                                            SlidingWindows(['1h', '2h'], '15m')),
+                            FieldAggregator("abc", "col3", ["sum"],
+                                            SlidingWindows(['24h'], '10m'))],
+                           "tal_table", 'https://webapi.default-tenant.app.dev60.lab.iguazeng.com/bigdata/',
+                           'f15588f4-9079-461e-8d9a-4f4529d686ae')
+
+    await store.aggregate('my-key', {'col1': 423, 'col2': 423, 'col3': 423}, datetime.now())
+    print('tal')
+
+
+def test_query_aggregate_by_key(setup_teardown_test):
+    controller = build_flow([
+        Source(),
+        AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
+                                        SlidingWindows(['1h', '2h', '24h'], '10m'))],
+                       setup_teardown_test),
+        Reduce([], lambda acc, x: append_return(acc, x)),
+    ]).run()
+
+    items_in_ingest_batch = 10
+    for i in range(items_in_ingest_batch):
+        data = {'col1': i}
+        print({'col1': i, 'time': test_base_time + timedelta(minutes=25 * i)})
+        controller.emit(data, 'tal', test_base_time + timedelta(minutes=25 * i))
+
+    controller.terminate()
+    actual = controller.await_termination()
+    expected_results = [
+        {'col1': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0, 'number_of_stuff_sum_24h': 0, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 0, 'number_of_stuff_max_2h': 0,
+         'number_of_stuff_max_24h': 0, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
+        {'col1': 1, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1, 'number_of_stuff_sum_24h': 1, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 1, 'number_of_stuff_max_2h': 1,
+         'number_of_stuff_max_24h': 1, 'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5, 'number_of_stuff_avg_24h': 0.5},
+        {'col1': 2, 'number_of_stuff_sum_1h': 3, 'number_of_stuff_sum_2h': 3, 'number_of_stuff_sum_24h': 3, 'number_of_stuff_min_1h': 0,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 2, 'number_of_stuff_max_2h': 2,
+         'number_of_stuff_max_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
+        {'col1': 3, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_min_1h': 1,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 3, 'number_of_stuff_max_2h': 3,
+         'number_of_stuff_max_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 1.5, 'number_of_stuff_avg_24h': 1.5},
+        {'col1': 4, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 10, 'number_of_stuff_sum_24h': 10, 'number_of_stuff_min_1h': 2,
+         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 4, 'number_of_stuff_max_2h': 4,
+         'number_of_stuff_max_24h': 4, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
+        {'col1': 5, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 15, 'number_of_stuff_sum_24h': 15,
+         'number_of_stuff_min_1h': 3, 'number_of_stuff_min_2h': 1, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 5,
+         'number_of_stuff_max_2h': 5, 'number_of_stuff_max_24h': 5, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 3.0,
+         'number_of_stuff_avg_24h': 2.5},
+        {'col1': 6, 'number_of_stuff_sum_1h': 15, 'number_of_stuff_sum_2h': 20, 'number_of_stuff_sum_24h': 21,
+         'number_of_stuff_min_1h': 4, 'number_of_stuff_min_2h': 2, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 6,
+         'number_of_stuff_max_2h': 6, 'number_of_stuff_max_24h': 6, 'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 4.0,
+         'number_of_stuff_avg_24h': 3.0},
+        {'col1': 7, 'number_of_stuff_sum_1h': 18, 'number_of_stuff_sum_2h': 25, 'number_of_stuff_sum_24h': 28,
+         'number_of_stuff_min_1h': 5, 'number_of_stuff_min_2h': 3, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 7,
+         'number_of_stuff_max_2h': 7, 'number_of_stuff_max_24h': 7, 'number_of_stuff_avg_1h': 6.0, 'number_of_stuff_avg_2h': 5.0,
+         'number_of_stuff_avg_24h': 3.5},
+        {'col1': 8, 'number_of_stuff_sum_1h': 21, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 36,
+         'number_of_stuff_min_1h': 6, 'number_of_stuff_min_2h': 4, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 8,
+         'number_of_stuff_max_2h': 8, 'number_of_stuff_max_24h': 8, 'number_of_stuff_avg_1h': 7.0, 'number_of_stuff_avg_2h': 6.0,
+         'number_of_stuff_avg_24h': 4.0},
+        {'col1': 9, 'number_of_stuff_sum_1h': 24, 'number_of_stuff_sum_2h': 35, 'number_of_stuff_sum_24h': 45,
+         'number_of_stuff_min_1h': 7, 'number_of_stuff_min_2h': 5, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9,
+         'number_of_stuff_max_2h': 9, 'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.0, 'number_of_stuff_avg_2h': 7.0,
+         'number_of_stuff_avg_24h': 4.5}
+    ]
+
+    assert actual == expected_results, \
+        f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
+
+    controller = build_flow([
+        Source(),
+        QueryAggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
+                                             SlidingWindows(['1h', '2h', '24h'], '10m'))],
+                            setup_teardown_test),
+        Reduce([], lambda acc, x: append_return(acc, x)),
+    ]).run()
+
+    base_time = test_base_time + timedelta(minutes=25 * items_in_ingest_batch)
+    data = {'col1': items_in_ingest_batch}
+    controller.emit(data, 'tal', base_time)
+
+    controller.terminate()
+    actual = controller.await_termination()
+    expected_results = [
+        {'col1': 10, 'number_of_stuff_sum_1h': 17, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 45,
+         'number_of_stuff_min_1h': 8, 'number_of_stuff_min_2h': 6, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9,
+         'number_of_stuff_max_2h': 9, 'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.5, 'number_of_stuff_avg_2h': 7.5,
+         'number_of_stuff_avg_24h': 4.5}
+    ]
 
     assert actual == expected_results, \
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'

--- a/tests/test_aggregate_by_key.py
+++ b/tests/test_aggregate_by_key.py
@@ -1,18 +1,10 @@
 from datetime import datetime, timedelta
-import asyncio
-import random
-import string
-from storey import build_flow, Source, Reduce, Map, V3ioTable
-from storey.aggregations import AggregateByKey, FieldAggregator, AggregateStore, QueryAggregationByKey
+
+from storey import build_flow, Source, Reduce
+from storey.aggregations import AggregateByKey, FieldAggregator
 from storey.dtypes import SlidingWindows, FixedWindows, EmitAfterMaxEvent
-import pytest
 
 test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
-
-
-def _generate_table_name(prefix='aggr_test'):
-    random_table = ''.join([random.choice(string.ascii_letters) for i in range(10)])
-    return f'{prefix}/{random_table}'
 
 
 class MockTable:
@@ -30,19 +22,6 @@ class MockTable:
 
     async def load_key(self, key):
         pass
-
-
-@pytest.fixture()
-def setup_teardown_test():
-    # Setup
-    table_name = _generate_table_name()
-    v3io_table = V3ioTable(table_name)
-
-    # Test runs
-    yield v3io_table
-
-    # Teardown
-    asyncio.run(v3io_table.delete())
 
 
 def append_return(lst, x):
@@ -346,88 +325,6 @@ def test_emit_max_event_sliding_window_multiple_keys_aggregation_flow():
          'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 5.0, 'number_of_stuff_avg_24h': 5.0},
         {'col1': 11, 'number_of_stuff_sum_1h': 36, 'number_of_stuff_sum_2h': 36, 'number_of_stuff_sum_24h': 36,
          'number_of_stuff_avg_1h': 6.0, 'number_of_stuff_avg_2h': 6.0, 'number_of_stuff_avg_24h': 6.0}]
-
-    assert actual == expected_results, \
-        f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
-
-
-def test_query_aggregate_by_key(setup_teardown_test):
-    controller = build_flow([
-        Source(),
-        AggregateByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
-                                        SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                       setup_teardown_test),
-        Reduce([], lambda acc, x: append_return(acc, x)),
-    ]).run()
-
-    items_in_ingest_batch = 10
-    for i in range(items_in_ingest_batch):
-        data = {'col1': i}
-        controller.emit(data, 'tal', test_base_time + timedelta(minutes=25 * i))
-
-    controller.terminate()
-    actual = controller.await_termination()
-    expected_results = [
-        {'col1': 0, 'number_of_stuff_sum_1h': 0, 'number_of_stuff_sum_2h': 0, 'number_of_stuff_sum_24h': 0, 'number_of_stuff_min_1h': 0,
-         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 0, 'number_of_stuff_max_2h': 0,
-         'number_of_stuff_max_24h': 0, 'number_of_stuff_avg_1h': 0.0, 'number_of_stuff_avg_2h': 0.0, 'number_of_stuff_avg_24h': 0.0},
-        {'col1': 1, 'number_of_stuff_sum_1h': 1, 'number_of_stuff_sum_2h': 1, 'number_of_stuff_sum_24h': 1, 'number_of_stuff_min_1h': 0,
-         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 1, 'number_of_stuff_max_2h': 1,
-         'number_of_stuff_max_24h': 1, 'number_of_stuff_avg_1h': 0.5, 'number_of_stuff_avg_2h': 0.5, 'number_of_stuff_avg_24h': 0.5},
-        {'col1': 2, 'number_of_stuff_sum_1h': 3, 'number_of_stuff_sum_2h': 3, 'number_of_stuff_sum_24h': 3, 'number_of_stuff_min_1h': 0,
-         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 2, 'number_of_stuff_max_2h': 2,
-         'number_of_stuff_max_24h': 2, 'number_of_stuff_avg_1h': 1.0, 'number_of_stuff_avg_2h': 1.0, 'number_of_stuff_avg_24h': 1.0},
-        {'col1': 3, 'number_of_stuff_sum_1h': 6, 'number_of_stuff_sum_2h': 6, 'number_of_stuff_sum_24h': 6, 'number_of_stuff_min_1h': 1,
-         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 3, 'number_of_stuff_max_2h': 3,
-         'number_of_stuff_max_24h': 3, 'number_of_stuff_avg_1h': 2.0, 'number_of_stuff_avg_2h': 1.5, 'number_of_stuff_avg_24h': 1.5},
-        {'col1': 4, 'number_of_stuff_sum_1h': 9, 'number_of_stuff_sum_2h': 10, 'number_of_stuff_sum_24h': 10, 'number_of_stuff_min_1h': 2,
-         'number_of_stuff_min_2h': 0, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 4, 'number_of_stuff_max_2h': 4,
-         'number_of_stuff_max_24h': 4, 'number_of_stuff_avg_1h': 3.0, 'number_of_stuff_avg_2h': 2.0, 'number_of_stuff_avg_24h': 2.0},
-        {'col1': 5, 'number_of_stuff_sum_1h': 12, 'number_of_stuff_sum_2h': 15, 'number_of_stuff_sum_24h': 15,
-         'number_of_stuff_min_1h': 3, 'number_of_stuff_min_2h': 1, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 5,
-         'number_of_stuff_max_2h': 5, 'number_of_stuff_max_24h': 5, 'number_of_stuff_avg_1h': 4.0, 'number_of_stuff_avg_2h': 3.0,
-         'number_of_stuff_avg_24h': 2.5},
-        {'col1': 6, 'number_of_stuff_sum_1h': 15, 'number_of_stuff_sum_2h': 20, 'number_of_stuff_sum_24h': 21,
-         'number_of_stuff_min_1h': 4, 'number_of_stuff_min_2h': 2, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 6,
-         'number_of_stuff_max_2h': 6, 'number_of_stuff_max_24h': 6, 'number_of_stuff_avg_1h': 5.0, 'number_of_stuff_avg_2h': 4.0,
-         'number_of_stuff_avg_24h': 3.0},
-        {'col1': 7, 'number_of_stuff_sum_1h': 18, 'number_of_stuff_sum_2h': 25, 'number_of_stuff_sum_24h': 28,
-         'number_of_stuff_min_1h': 5, 'number_of_stuff_min_2h': 3, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 7,
-         'number_of_stuff_max_2h': 7, 'number_of_stuff_max_24h': 7, 'number_of_stuff_avg_1h': 6.0, 'number_of_stuff_avg_2h': 5.0,
-         'number_of_stuff_avg_24h': 3.5},
-        {'col1': 8, 'number_of_stuff_sum_1h': 21, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 36,
-         'number_of_stuff_min_1h': 6, 'number_of_stuff_min_2h': 4, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 8,
-         'number_of_stuff_max_2h': 8, 'number_of_stuff_max_24h': 8, 'number_of_stuff_avg_1h': 7.0, 'number_of_stuff_avg_2h': 6.0,
-         'number_of_stuff_avg_24h': 4.0},
-        {'col1': 9, 'number_of_stuff_sum_1h': 24, 'number_of_stuff_sum_2h': 35, 'number_of_stuff_sum_24h': 45,
-         'number_of_stuff_min_1h': 7, 'number_of_stuff_min_2h': 5, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9,
-         'number_of_stuff_max_2h': 9, 'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.0, 'number_of_stuff_avg_2h': 7.0,
-         'number_of_stuff_avg_24h': 4.5}
-    ]
-
-    assert actual == expected_results, \
-        f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'
-
-    controller = build_flow([
-        Source(),
-        QueryAggregationByKey([FieldAggregator("number_of_stuff", "col1", ["sum", "avg", "min", "max"],
-                                               SlidingWindows(['1h', '2h', '24h'], '10m'))],
-                              setup_teardown_test),
-        Reduce([], lambda acc, x: append_return(acc, x)),
-    ]).run()
-
-    base_time = test_base_time + timedelta(minutes=25 * items_in_ingest_batch)
-    data = {'col1': items_in_ingest_batch}
-    controller.emit(data, 'tal', base_time)
-
-    controller.terminate()
-    actual = controller.await_termination()
-    expected_results = [
-        {'col1': 10, 'number_of_stuff_sum_1h': 17, 'number_of_stuff_sum_2h': 30, 'number_of_stuff_sum_24h': 45,
-         'number_of_stuff_min_1h': 8, 'number_of_stuff_min_2h': 6, 'number_of_stuff_min_24h': 0, 'number_of_stuff_max_1h': 9,
-         'number_of_stuff_max_2h': 9, 'number_of_stuff_max_24h': 9, 'number_of_stuff_avg_1h': 8.5, 'number_of_stuff_avg_2h': 7.5,
-         'number_of_stuff_avg_24h': 4.5}
-    ]
 
     assert actual == expected_results, \
         f'actual did not match expected. \n actual: {actual} \n expected: {expected_results}'


### PR DESCRIPTION
* create, save and load schema file
* separate 'AggregateByKey' to ingest ('AggregateByKey' ) and serving ('QueryAggregationByKey') flows
* Save the aggregation store after every aggregation
* load aggregation state from store when needed
* add aggregation integration tests with setup and teardown